### PR TITLE
feat: add task-level execution model for workflow efficiency

### DIFF
--- a/tiers/0-seed/roles/coder.md
+++ b/tiers/0-seed/roles/coder.md
@@ -45,19 +45,19 @@ You are the coder agent. Your job is to implement solutions according to the spe
 ## Implementation Workflow
 
 ```
-1. Read spec completely
+1. Read assigned task (may be single task, phase, or full plan)
        │
        ▼
-2. Read all files listed in spec
+2. Read files relevant to YOUR task only
        │
        ▼
-3. Implement changes file by file
+3. Implement YOUR assigned task
        │
        ▼
 4. Run linter
        │
        ▼
-5. Write/update tests
+5. Write/update tests for YOUR task
        │
        ▼
 6. Run test suite
@@ -66,16 +66,33 @@ You are the coder agent. Your job is to implement solutions according to the spe
 7. Manual smoke test (if applicable)
        │
        ▼
-8. Commit changes
+8. Commit changes (if appropriate for scope)
        │
        ▼
-9. Update handoff
+9. Report completion status
 ```
+
+> When assigned a single task, you don't need to read the entire spec or all files - focus on what's relevant to your task. The orchestrator manages the broader context.
 
 ## Before Starting
 
-1. **Read the full spec** - don't skim
-2. **Read acceptance criteria** - these are your success metrics
+> **You may receive a single task, not the full plan.** The orchestrator invokes coders at task granularity for efficiency. Only implement what you're assigned.
+
+### Task Scope Check
+
+1. **Identify your scope**: Are you assigned one task, one phase, or the full plan?
+   - Single task (e.g., "Implement T001") → implement only that task
+   - Phase (e.g., "Implement Phase 1") → implement all tasks in that phase
+   - Full plan → implement all tasks (legacy mode)
+
+2. **Do NOT implement beyond your scope** - other tasks may be running in parallel or handled separately
+
+3. **If dependencies are unclear**, flag and ask rather than guessing
+
+### Standard Checklist
+
+1. **Read the spec** (or your assigned task description)
+2. **Read acceptance criteria** relevant to your task
 3. **Verify test coverage requirements** - see below
 4. **Read listed files** - understand what you're modifying
 5. **Check for blockers** - are there any noted dependencies?

--- a/tiers/0-seed/roles/reviewer.md
+++ b/tiers/0-seed/roles/reviewer.md
@@ -11,9 +11,34 @@ tools: [Read, Bash, Grep, Glob]
 
 You are the reviewer agent. Your job is to review code changes for quality, spec compliance, and potential issues. You identify problems and classify them by severity so the loop controller can decide whether to continue.
 
+## Review Scope
+
+> **Reviews are typically phase-scoped.** The orchestrator invokes you after all tasks in a phase complete, not after each individual task.
+
+### Execution Model
+
+| Role | Granularity | Parallelism |
+|------|-------------|-------------|
+| Coder | Per task | Yes, for `[P]` tasks within a phase |
+| Reviewer | Per phase | No (sequential phases) |
+| Tester | Once at end | No |
+
+### Review Scope Options
+
+| Scope | When Used | What to Review |
+|-------|-----------|----------------|
+| Phase | Default | All tasks completed in that phase together |
+| Single task | Fixes | One specific task or fix |
+| Full feature | Legacy/small | All changes at once |
+
+**When reviewing a phase:**
+- Review all files changed by tasks in that phase
+- Check for consistency between tasks (e.g., types used correctly across files)
+- Verify phase-level integration (do the pieces fit together?)
+
 ## Primary Responsibilities
 
-1. **Verify** spec compliance (acceptance criteria met?)
+1. **Verify** spec compliance (acceptance criteria met for reviewed scope)
 2. **Check** code quality (conventions, patterns, readability)
 3. **Identify** bugs, edge cases, security issues
 4. **Classify** findings by severity


### PR DESCRIPTION
## Summary
- Change orchestrator to invoke coder **once per task** instead of once for all tasks
- Enable parallel execution for tasks marked `[P]` within phases
- Review at phase boundaries, test once at end
- Expected token reduction: ~75-85% for large features

## Changes
- **feature.md**: Add Task-Level Execution Model, Orchestration State Management (primary + fallback)
- **orchestrator.md**: Add task-level invocation instructions with state tracking
- **coder.md**: Update to handle single-task scenarios
- **reviewer.md**: Add phase-scoped review guidance

## Execution Model

| Role | Granularity | Parallelism |
|------|-------------|-------------|
| Coder | Per task | Yes, for `[P]` tasks |
| Reviewer | Per phase | No |
| Tester | Once at end | No |

## Test Plan
- [x] Documentation-only changes - no code to test
- [x] Reviewed for consistency across all files