### PR TITLE
feat(adapters): multi-tool adapter support with bootstrap selection

### DIFF
--- a/adapters/agentskills/adapter.yaml
+++ b/adapters/agentskills/adapter.yaml
@@ -1,0 +1,15 @@
+adapter: agentskills
+version: 1
+
+output:
+  skills: .agent/skills
+
+skills:
+  strategy: symlink
+
+# No model sets - skills only adapter
+model_sets:
+  enabled: false
+
+roles:
+  enabled: false

--- a/adapters/claude-code/adapter.yaml
+++ b/adapters/claude-code/adapter.yaml
@@ -1,0 +1,25 @@
+adapter: claude
+version: 1
+
+output:
+  agents: .claude/agents
+  skills: .claude/skills
+
+skills:
+  strategy: symlink
+
+model_sets:
+  enabled: true
+  default: default
+
+roles:
+  format: markdown
+  filename: "{name}.md"
+
+tools:
+  Read: Read
+  Write: Write
+  Edit: Edit
+  Bash: Bash
+  Grep: Grep
+  Glob: Glob

--- a/adapters/claude-code/model-sets/default.yaml
+++ b/adapters/claude-code/model-sets/default.yaml
@@ -1,0 +1,14 @@
+name: default
+description: Standard Claude models
+default: true
+
+roles:
+  orchestrator: opus
+  analyst: opus
+  coder: sonnet
+  reviewer: opus
+  debug: opus
+  product-designer: opus
+  tester: sonnet
+  docs: sonnet
+  triage: haiku

--- a/adapters/factory/adapter.yaml
+++ b/adapters/factory/adapter.yaml
@@ -1,0 +1,26 @@
+adapter: factory
+version: 1
+
+output:
+  droids: .factory/droids
+  skills: .factory/skills
+
+skills:
+  strategy: symlink
+
+model_sets:
+  enabled: true
+  default: balanced
+
+roles:
+  format: markdown
+  filename: "{name}.md"
+
+# Factory tool names (Write->Create, Bash->Execute)
+tools:
+  Read: Read
+  Write: Create
+  Edit: Edit
+  Bash: Execute
+  Grep: Grep
+  Glob: Glob

--- a/adapters/factory/model-sets/balanced.yaml
+++ b/adapters/factory/model-sets/balanced.yaml
@@ -1,0 +1,18 @@
+name: balanced
+description: Quality with cost balance
+default: true
+
+roles:
+  orchestrator: claude-opus-4-5-20251101
+  analyst: claude-opus-4-5-20251101
+  coder: claude-opus-4-5-20251101
+  reviewer:
+    model: gpt-5.2-codex
+    reasoningEffort: high
+  debug:
+    model: gpt-5.2-codex
+    reasoningEffort: high
+  product-designer: gemini-3-pro-preview
+  tester: gpt-5.2-codex
+  docs: claude-sonnet-4-5-20250929
+  triage: gpt-5.2-codex

--- a/adapters/factory/model-sets/optimal.yaml
+++ b/adapters/factory/model-sets/optimal.yaml
@@ -1,0 +1,17 @@
+name: optimal
+description: Speed + quality guards - xhigh analyst, Opus reviewer
+
+roles:
+  orchestrator: claude-opus-4-5-20251101
+  analyst:
+    model: gpt-5.2-codex
+    reasoningEffort: xhigh
+  coder: custom:Cerebras:-zai-glm-4.7-0
+  reviewer: claude-opus-4-5-20251101
+  debug:
+    model: gpt-5.2-codex
+    reasoningEffort: high
+  product-designer: gemini-3-pro-preview
+  tester: custom:Cerebras:-zai-glm-4.7-0
+  docs: custom:Cerebras:-gpt-oss-120b-1
+  triage: gemini-3-flash-preview

--- a/adapters/factory/model-sets/speed.yaml
+++ b/adapters/factory/model-sets/speed.yaml
@@ -1,0 +1,19 @@
+name: speed
+description: Fast iteration - quality upfront, Cerebras execution
+
+roles:
+  orchestrator:
+    model: gpt-5.2-codex
+    reasoningEffort: high
+  analyst:
+    model: gpt-5.2-codex
+    reasoningEffort: xhigh
+  coder: custom:Cerebras:-zai-glm-4.7-0
+  reviewer: custom:Cerebras:-zai-glm-4.7-0
+  debug:
+    model: gpt-5.2-codex
+    reasoningEffort: high
+  product-designer: gemini-3-pro-preview
+  tester: custom:Cerebras:-zai-glm-4.7-0
+  docs: custom:Cerebras:-gpt-oss-120b-1
+  triage: custom:Cerebras:-zai-glm-4.7-0

--- a/adapters/opencode/adapter.yaml
+++ b/adapters/opencode/adapter.yaml
@@ -1,0 +1,26 @@
+adapter: opencode
+version: 1
+
+output:
+  agents: .opencode/agent
+  skills: .opencode/skills
+
+skills:
+  strategy: symlink
+
+model_sets:
+  enabled: true
+  default: antigravity
+
+roles:
+  format: markdown
+  filename: "{name}.md"
+
+# Tool name mapping (lowercase for opencode)
+tools:
+  Read: read
+  Write: write
+  Edit: edit
+  Bash: bash
+  Grep: grep
+  Glob: glob

--- a/adapters/opencode/model-sets/antigravity.yaml
+++ b/adapters/opencode/model-sets/antigravity.yaml
@@ -1,0 +1,14 @@
+name: antigravity
+description: Gemini 3 + Claude via Antigravity plugin
+default: true
+
+roles:
+  orchestrator: google/antigravity-claude-opus-4-5-thinking-low
+  analyst: google/antigravity-gemini-3-pro-high
+  coder: google/antigravity-claude-opus-4-5-thinking-low
+  reviewer: google/antigravity-claude-opus-4-5-thinking-high
+  debug: google/antigravity-claude-opus-4-5-thinking-high
+  product-designer: google/antigravity-gemini-3-pro-high
+  tester: google/antigravity-gemini-3-flash
+  docs: google/antigravity-gemini-3-flash
+  triage: google/antigravity-gemini-3-flash

--- a/adapters/opencode/model-sets/codex-5.2.yaml
+++ b/adapters/opencode/model-sets/codex-5.2.yaml
@@ -1,0 +1,31 @@
+name: codex-5.2
+description: 100% GPT-5.2-codex with reasoning levels
+
+roles:
+  orchestrator:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: low
+  analyst:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: xhigh
+  coder:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: high
+  reviewer:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: xhigh
+  debug:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: high
+  product-designer:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: high
+  tester:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: medium
+  docs:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: medium
+  triage:
+    model: openai/gpt-5.2-codex
+    reasoningEffort: low

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,26 @@ echo "Bootstrapping aix in: $REPO_ROOT"
 echo "Using framework from: $AIX_FRAMEWORK"
 echo ""
 
+# Parse command line arguments
+ADAPTER="${ADAPTER:-}"
+SKIP_PROMPT="${SKIP_PROMPT:-false}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --adapter)
+            ADAPTER="$2"
+            shift 2
+            ;;
+        --skip-prompt)
+            SKIP_PROMPT=true
+            shift
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
 # Check if already initialized
 if [ -d "$REPO_ROOT/.aix" ]; then
     echo "aix already initialized. Run /aix-init upgrade to upgrade."
@@ -126,7 +146,39 @@ if [ -f "$MANIFEST_TOOL" ]; then
         --aix-version "$AIX_VERSION"
 fi
 
-# Create tier.yaml
+# Select coding assistant adapter
+select_adapter() {
+    if [ -n "$ADAPTER" ]; then
+        echo "$ADAPTER"
+        return
+    fi
+
+    if [ "$SKIP_PROMPT" = true ]; then
+        echo "claude"
+        return
+    fi
+
+    echo ""
+    echo "Select your coding assistant:"
+    echo "  1) Claude Code (recommended)"
+    echo "  2) OpenCode"
+    echo "  3) Factory/Droid"
+    echo "  4) Agent Skills (MCP-based tools)"
+    echo ""
+    read -p "Enter choice [1]: " choice
+
+    case "$choice" in
+        2) echo "opencode" ;;
+        3) echo "factory" ;;
+        4) echo "agentskills" ;;
+        *) echo "claude" ;;
+    esac
+}
+
+SELECTED_ADAPTER=$(select_adapter)
+echo "Selected adapter: $SELECTED_ADAPTER"
+
+# Create tier.yaml with adapter config
 cat > "$REPO_ROOT/.aix/tier.yaml" << EOF
 tier: 0
 name: seed
@@ -136,11 +188,41 @@ history:
   - tier: 0
     date: $(date -I)
     reason: initial bootstrap
+
+adapters:
+  $SELECTED_ADAPTER:
+    enabled: true
+    model_set: default
 EOF
 
-# Run Claude Code adapter
-echo "Setting up Claude Code integration..."
-"$AIX_FRAMEWORK/adapters/claude-code/generate.sh" 0
+# Copy adapter config
+echo "Setting up $SELECTED_ADAPTER adapter..."
+ADAPTER_DIR=""
+case "$SELECTED_ADAPTER" in
+    claude) ADAPTER_DIR="claude-code" ;;
+    opencode) ADAPTER_DIR="opencode" ;;
+    factory) ADAPTER_DIR="factory" ;;
+    agentskills) ADAPTER_DIR="agentskills" ;;
+esac
+
+if [ -d "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR" ]; then
+    mkdir -p "$REPO_ROOT/.aix/adapters/$SELECTED_ADAPTER"
+    cp "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/adapter.yaml" "$REPO_ROOT/.aix/adapters/$SELECTED_ADAPTER/"
+    if [ -d "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/model-sets" ]; then
+        cp -r "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/model-sets" "$REPO_ROOT/.aix/adapters/$SELECTED_ADAPTER/"
+    fi
+fi
+
+# Generate adapter output using aix-generate.py
+if [ -f "$REPO_ROOT/.aix/scripts/aix-generate.py" ]; then
+    echo "Generating adapter configurations..."
+    python3 "$REPO_ROOT/.aix/scripts/aix-generate.py" --adapter "$SELECTED_ADAPTER" 2>/dev/null || true
+fi
+
+# Legacy: Run Claude Code adapter script for symlinks if claude selected
+if [ "$SELECTED_ADAPTER" = "claude" ] && [ -f "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" ]; then
+    "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" 0
+fi
 
 # Create .gitignore additions
 if [ -f "$REPO_ROOT/.gitignore" ]; then
@@ -170,13 +252,36 @@ echo "  ├── config.yaml"
 echo "  ├── tier.yaml"
 echo "  ├── roles/ (analyst, coder, reviewer)"
 echo "  ├── workflows/ (standard)"
-echo "  └── skills/ (aix-init, aix-sync)"
+echo "  ├── skills/ (aix-init, aix-sync)"
+echo "  └── adapters/$SELECTED_ADAPTER/"
 echo ""
-echo "  .claude/"
-echo "  ├── agents -> .aix/roles"
-echo "  └── skills -> .aix/skills"
-echo ""
-echo "  CLAUDE.md -> .aix/constitution.md"
+
+case "$SELECTED_ADAPTER" in
+    claude)
+        echo "  .claude/"
+        echo "  ├── agents/"
+        echo "  └── skills/"
+        echo ""
+        echo "  CLAUDE.md -> .aix/constitution.md"
+        ;;
+    opencode)
+        echo "  .opencode/"
+        echo "  ├── agent/"
+        echo "  └── skills/"
+        echo ""
+        echo "  AGENTS.md -> .aix/constitution.md"
+        ;;
+    factory)
+        echo "  .factory/"
+        echo "  ├── droids/"
+        echo "  └── skills/"
+        ;;
+    agentskills)
+        echo "  .agent/"
+        echo "  └── skills/"
+        ;;
+esac
+
 echo ""
 echo "  docs/"
 echo "  ├── product.md   <- Fill this in!"
@@ -186,6 +291,7 @@ echo ""
 echo "Next steps:"
 echo "  1. Fill in docs/product.md with your vision"
 echo "  2. Review docs/tech-stack.md"
-echo "  3. Open Claude Code and start building!"
+echo "  3. Open your coding assistant and start building!"
 echo ""
 echo "Run /aix-init upgrade when ready for more structure."
+echo "Run /aix-init --add-adapter <name> to add another adapter."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -219,10 +219,26 @@ if [ -f "$REPO_ROOT/.aix/scripts/aix-generate.py" ]; then
     python3 "$REPO_ROOT/.aix/scripts/aix-generate.py" --adapter "$SELECTED_ADAPTER" 2>/dev/null || true
 fi
 
-# Legacy: Run Claude Code adapter script for symlinks if claude selected
-if [ "$SELECTED_ADAPTER" = "claude" ] && [ -f "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" ]; then
-    "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" 0
-fi
+# Create entry point symlink based on adapter
+case "$SELECTED_ADAPTER" in
+    claude)
+        # Legacy: Run Claude Code adapter script for symlinks
+        if [ -f "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" ]; then
+            "$AIX_FRAMEWORK/adapters/claude-code/generate.sh" 0
+        fi
+        ;;
+    opencode)
+        ln -sf .aix/constitution.md "$REPO_ROOT/AGENTS.md"
+        echo "✓ Created AGENTS.md -> .aix/constitution.md"
+        ;;
+    factory)
+        ln -sf .aix/constitution.md "$REPO_ROOT/GEMINI.md"
+        echo "✓ Created GEMINI.md -> .aix/constitution.md"
+        ;;
+    agentskills)
+        # No entry point needed for agent skills
+        ;;
+esac
 
 # Create .gitignore additions
 if [ -f "$REPO_ROOT/.gitignore" ]; then

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -219,7 +219,7 @@ if [ -d "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR" ]; then
     fi
     # Extract default model set from adapter.yaml
     if [ -f "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/adapter.yaml" ]; then
-        DEFAULT_MODEL_SET=$(grep -A1 "model_sets:" "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/adapter.yaml" | grep "default:" | sed 's/.*default: *//' | tr -d ' ')
+        DEFAULT_MODEL_SET=$(grep -A2 "model_sets:" "$AIX_FRAMEWORK/adapters/$ADAPTER_DIR/adapter.yaml" | grep "default:" | sed 's/.*default: *//' | tr -d ' ')
     fi
 fi
 

--- a/registry.tsv
+++ b/registry.tsv
@@ -1,4 +1,9 @@
 # name	tier	type	subpath	notes
+adapter-core	0	script	scripts/aix-generate.py	Adapter generator script
+adapter-claude	0	adapter	adapters/claude-code	Claude Code adapter
+adapter-opencode	0	adapter	adapters/opencode	OpenCode adapter
+adapter-factory	0	adapter	adapters/factory	Factory/droid adapter
+adapter-agentskills	0	adapter	adapters/agentskills	Skills-only adapter (MCP tools)
 test	1	skill	skills/test	Run tests
 commit	1	skill	skills/commit	Commit helper
 tester	1	role	roles/tester.md	Tester role

--- a/scripts/aix-generate.py
+++ b/scripts/aix-generate.py
@@ -1,0 +1,706 @@
+#!/usr/bin/env python3
+"""
+Generate tool-specific configurations from canonical AIX role definitions.
+
+This script reads canonical role files from .aix/roles/ and generates
+adapter-specific agent configurations for supported coding assistants.
+
+Usage:
+    python3 .aix/scripts/aix-generate.py --adapter claude
+    python3 .aix/scripts/aix-generate.py --adapter opencode --model-set codex-5.2
+    python3 .aix/scripts/aix-generate.py --adapter factory --model-set speed
+    python3 .aix/scripts/aix-generate.py --adapter agentskills
+    python3 .aix/scripts/aix-generate.py --all
+    python3 .aix/scripts/aix-generate.py --adapter claude --dry-run
+    python3 .aix/scripts/aix-generate.py --adapter claude --force
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:
+    print("Error: PyYAML is required. Install with: pip install pyyaml")
+    exit(1)
+
+
+def _git_root() -> Path:
+    """Get git repository root directory."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def _sha256(content: str) -> str:
+    """Compute SHA-256 hash of string content."""
+    return hashlib.sha256(content.encode()).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute SHA-256 hash of file content."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_adapter_config(adapter_path: Path) -> Dict[str, Any]:
+    """
+    Load adapter configuration from adapter.yaml.
+
+    Args:
+        adapter_path: Path to adapter directory
+
+    Returns:
+        Dict with adapter config
+
+    Raises:
+        FileNotFoundError: If adapter.yaml doesn't exist
+        ValueError: If config is invalid
+    """
+    config_path = adapter_path / "adapter.yaml"
+    if not config_path.exists():
+        raise FileNotFoundError(f"Adapter config not found: {config_path}")
+
+    config = yaml.safe_load(config_path.read_text())
+
+    # Validate required fields
+    required = ["adapter", "version"]
+    for field in required:
+        if field not in config:
+            raise ValueError(f"Missing required field in adapter config: {field}")
+
+    return config
+
+
+def load_model_set(adapter_path: Path, model_set_name: str) -> Dict[str, Any]:
+    """
+    Load model set configuration from adapter's model-sets directory.
+
+    Args:
+        adapter_path: Path to adapter directory
+        model_set_name: Name of model set to load
+
+    Returns:
+        Dict with model set config
+
+    Raises:
+        FileNotFoundError: If model set doesn't exist
+    """
+    model_set_path = adapter_path / "model-sets" / f"{model_set_name}.yaml"
+    if not model_set_path.exists():
+        raise FileNotFoundError(f"Model set not found: {model_set_path}")
+
+    return yaml.safe_load(model_set_path.read_text())
+
+
+def resolve_model_for_role(role_name: str, model_set: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Resolve model configuration for a role from model set.
+
+    Args:
+        role_name: Name of the role (e.g., 'analyst', 'coder')
+        model_set: Model set configuration dict
+
+    Returns:
+        Dict with 'model' key and optional 'reasoningEffort' key
+        Returns empty dict if role not found in model set
+    """
+    roles = model_set.get("roles", {})
+    role_config = roles.get(role_name)
+
+    if role_config is None:
+        return {}
+
+    # Handle simple string format: "role: opus"
+    if isinstance(role_config, str):
+        return {"model": role_config}
+
+    # Handle object format: "role: {model: opus, reasoningEffort: high}"
+    if isinstance(role_config, dict):
+        result = {}
+        if "model" in role_config:
+            result["model"] = role_config["model"]
+        if "reasoningEffort" in role_config:
+            result["reasoningEffort"] = role_config["reasoningEffort"]
+        return result
+
+    return {}
+
+
+def parse_role_file(role_path: Path) -> Tuple[Dict[str, Any], str]:
+    """
+    Parse role markdown file to extract YAML frontmatter and body.
+
+    Args:
+        role_path: Path to role markdown file
+
+    Returns:
+        Tuple of (frontmatter_dict, body_content)
+
+    Raises:
+        ValueError: If file format is invalid
+    """
+    content = role_path.read_text()
+
+    # Match YAML frontmatter between --- markers (with optional leading HTML comments)
+    pattern = r'^(?:<!--.*?-->\s*\n)*---\s*\n(.*?)\n---\s*\n(.*)$'
+    match = re.match(pattern, content, re.DOTALL)
+
+    if not match:
+        raise ValueError(f"Invalid role file format (missing frontmatter): {role_path}")
+
+    frontmatter_str = match.group(1)
+    body = match.group(2)
+
+    try:
+        frontmatter = yaml.safe_load(frontmatter_str)
+        if frontmatter is None:
+            frontmatter = {}
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML frontmatter in {role_path}: {e}")
+
+    return frontmatter, body
+
+
+def map_tool_names(tools: List[str], adapter_config: Dict[str, Any]) -> List[str]:
+    """
+    Map canonical AIX tool names to adapter-specific tool names.
+
+    Args:
+        tools: List of canonical tool names (e.g., ['Read', 'Write'])
+        adapter_config: Adapter configuration dict
+
+    Returns:
+        List of adapter-specific tool names
+    """
+    tool_mapping = adapter_config.get("tools", {})
+    return [tool_mapping.get(tool, tool) for tool in tools]
+
+
+def generate_output_file(
+    role_name: str,
+    frontmatter: Dict[str, Any],
+    body: str,
+    adapter_config: Dict[str, Any],
+    model_config: Dict[str, Any],
+    model_set_name: str,
+) -> str:
+    """
+    Generate output file content for a role.
+
+    Args:
+        role_name: Name of the role
+        frontmatter: Role frontmatter dict
+        body: Role body content
+        adapter_config: Adapter configuration
+        model_config: Model configuration for this role
+        model_set_name: Name of model set being used
+
+    Returns:
+        Complete output file content as string
+    """
+    # Build new frontmatter (no header comments - they break frontmatter detection)
+    new_frontmatter = {}
+
+    # Add name and description if present
+    if "name" in frontmatter:
+        new_frontmatter["name"] = frontmatter["name"]
+    if "description" in frontmatter:
+        new_frontmatter["description"] = frontmatter["description"]
+
+    # Add model from model set
+    if "model" in model_config:
+        new_frontmatter["model"] = model_config["model"]
+
+    # Add reasoningEffort if present
+    if "reasoningEffort" in model_config:
+        new_frontmatter["reasoningEffort"] = model_config["reasoningEffort"]
+
+    # Map and add tools (handle both 'tools' and 'allowed_tools' from source)
+    # Get adapter name for format-specific handling
+    adapter_name = adapter_config.get("adapter", "")
+
+    # Add mode for OpenCode (required field)
+    if adapter_name == "opencode":
+        new_frontmatter["mode"] = "subagent"
+
+    # Map and add tools (format varies by adapter)
+    tools = frontmatter.get("tools") or frontmatter.get("allowed_tools")
+    if tools and isinstance(tools, list):
+        mapped_tools = map_tool_names(tools, adapter_config)
+
+        if adapter_name == "opencode":
+            # OpenCode uses object format with boolean values: {read: true, write: true}
+            new_frontmatter["tools"] = {tool: True for tool in mapped_tools}
+        else:
+            # Claude and others use array format: [Read, Write, Bash]
+            new_frontmatter["tools"] = mapped_tools
+
+    # Convert frontmatter to YAML with flow style for tools list
+    # Use custom representer to output short lists in flow style
+    class FlowStyleDumper(yaml.SafeDumper):
+        pass
+
+    def represent_list(dumper, data):
+        # Use flow style for short lists (like tools)
+        if len(data) <= 10 and all(isinstance(item, str) for item in data):
+            return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=True)
+        return dumper.represent_sequence('tag:yaml.org,2002:seq', data, flow_style=False)
+
+    FlowStyleDumper.add_representer(list, represent_list)
+
+    frontmatter_yaml = yaml.dump(new_frontmatter, Dumper=FlowStyleDumper, sort_keys=False, width=float("inf"))
+
+    # Combine into final output
+    output = "---\n" + frontmatter_yaml + "---\n\n" + body.strip() + "\n"
+
+    return output
+
+
+def create_skills_symlink(output_dir: Path, skills_source: Path) -> None:
+    """
+    Create symlink from output skills directory to canonical skills directory.
+
+    Args:
+        output_dir: Directory where symlink should be created
+        skills_source: Canonical skills directory (.aix/skills)
+    """
+    # Compute relative path from output_dir to skills_source
+    try:
+        rel_path = os.path.relpath(skills_source, output_dir.parent)
+    except ValueError:
+        # On Windows, relpath can fail if paths are on different drives
+        rel_path = str(skills_source)
+
+    # Remove existing symlink/directory if present
+    if output_dir.exists() or output_dir.is_symlink():
+        if output_dir.is_symlink():
+            output_dir.unlink()
+        elif output_dir.is_dir() and not any(output_dir.iterdir()):
+            output_dir.rmdir()
+
+    # Create parent directory if needed
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    # Create symlink
+    output_dir.symlink_to(rel_path)
+
+
+def compute_content_hash(content: str) -> str:
+    """
+    Compute SHA-256 hash of content.
+
+    Args:
+        content: String content to hash
+
+    Returns:
+        Hex string of SHA-256 hash
+    """
+    return _sha256(content)
+
+
+def load_manifest(manifest_path: Path) -> Dict[str, Any]:
+    """Load manifest.json file."""
+    if not manifest_path.exists():
+        return {
+            "manifest_version": 1,
+            "files": [],
+            "generated": {}
+        }
+    return json.loads(manifest_path.read_text())
+
+
+def update_manifest(
+    manifest_path: Path,
+    adapter_name: str,
+    generation_info: Dict[str, Any]
+) -> None:
+    """
+    Update manifest.json with generation metadata.
+
+    Args:
+        manifest_path: Path to manifest.json
+        adapter_name: Name of adapter that was generated
+        generation_info: Dict with generation metadata
+    """
+    manifest = load_manifest(manifest_path)
+
+    # Initialize generated section if not present
+    if "generated" not in manifest:
+        manifest["generated"] = {}
+
+    # Update adapter entry
+    manifest["generated"][adapter_name] = generation_info
+
+    # Write back to file
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def get_enabled_adapters(repo_root: Path) -> Dict[str, str]:
+    """
+    Get list of enabled adapters and their model sets from tier.yaml.
+
+    Returns:
+        Dict mapping adapter name to model set name
+        Empty dict if tier.yaml doesn't exist or has no adapters section
+    """
+    tier_path = repo_root / ".aix" / "tier.yaml"
+    if not tier_path.exists():
+        return {}
+
+    # Simple YAML parsing for tier.yaml
+    content = tier_path.read_text()
+    adapters = {}
+    in_adapters = False
+
+    for line in content.splitlines():
+        line = line.rstrip()
+
+        if line.startswith("adapters:"):
+            in_adapters = True
+            continue
+
+        if in_adapters:
+            # End of adapters section
+            if line and not line.startswith(" "):
+                break
+
+            # Parse adapter entry: "  claude:"
+            if line.strip().endswith(":") and not line.strip().startswith("#"):
+                adapter_name = line.strip()[:-1]
+                adapters[adapter_name] = None
+                continue
+
+            # Parse enabled field: "    enabled: true"
+            if "enabled:" in line:
+                parts = line.split("enabled:")
+                if len(parts) == 2:
+                    enabled = parts[1].strip().lower() == "true"
+                    # If disabled, remove from dict
+                    if not enabled and adapter_name in adapters:
+                        del adapters[adapter_name]
+
+            # Parse model_set field: "    model_set: default"
+            if "model_set:" in line:
+                parts = line.split("model_set:")
+                if len(parts) == 2 and adapter_name in adapters:
+                    adapters[adapter_name] = parts[1].strip()
+
+    return adapters
+
+
+def generate_adapter(
+    repo_root: Path,
+    adapter_name: str,
+    model_set_name: Optional[str] = None,
+    dry_run: bool = False,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """
+    Generate configurations for a specific adapter.
+
+    Args:
+        repo_root: Repository root path
+        adapter_name: Name of adapter to generate
+        model_set_name: Optional model set override
+        dry_run: If True, don't write files
+        force: If True, regenerate even if unchanged
+
+    Returns:
+        Dict with generation report
+    """
+    aix_dir = repo_root / ".aix"
+    adapter_path = aix_dir / "adapters" / adapter_name
+    roles_dir = aix_dir / "roles"
+    manifest_path = aix_dir / "manifest.json"
+
+    # Load adapter config
+    try:
+        adapter_config = load_adapter_config(adapter_path)
+    except (FileNotFoundError, ValueError) as e:
+        return {
+            "adapter": adapter_name,
+            "status": "error",
+            "error": str(e),
+        }
+
+    # Determine model set to use
+    if model_set_name is None:
+        # Use default from adapter config
+        model_sets_config = adapter_config.get("model_sets", {})
+        if model_sets_config.get("enabled"):
+            model_set_name = model_sets_config.get("default", "default")
+
+    # Load model set (if adapter uses model sets)
+    model_set = None
+    model_set_hash = None
+    if adapter_config.get("model_sets", {}).get("enabled"):
+        try:
+            model_set = load_model_set(adapter_path, model_set_name)
+            model_set_file = adapter_path / "model-sets" / f"{model_set_name}.yaml"
+            model_set_hash = _sha256_file(model_set_file)
+        except FileNotFoundError as e:
+            return {
+                "adapter": adapter_name,
+                "status": "error",
+                "error": str(e),
+            }
+
+    # Get output directories from adapter config
+    output_config = adapter_config.get("output", {})
+
+    # Setup skills symlink if configured
+    skills_config = adapter_config.get("skills", {})
+    if skills_config.get("strategy") == "symlink":
+        skills_output_key = "skills"
+        if skills_output_key in output_config:
+            skills_output = repo_root / output_config[skills_output_key]
+            skills_source = aix_dir / "skills"
+
+            if not dry_run:
+                create_skills_symlink(skills_output, skills_source)
+
+    # If adapter has roles disabled (skills-only), skip role generation
+    if not adapter_config.get("roles", {}).get("enabled", True):
+        generation_info = {
+            "last_generated": datetime.utcnow().isoformat() + "Z",
+            "skills_symlink": str(output_config.get("skills", "")),
+            "adapter_config_hash": _sha256_file(adapter_path / "adapter.yaml"),
+        }
+
+        if not dry_run:
+            update_manifest(manifest_path, adapter_name, generation_info)
+
+        return {
+            "adapter": adapter_name,
+            "status": "success",
+            "model_set": None,
+            "roles_generated": 0,
+            "skills_symlink_created": True,
+            "dry_run": dry_run,
+        }
+
+    # Get output directory for agents/droids
+    agent_output_key = None
+    for key in ["agents", "droids", "agent"]:
+        if key in output_config:
+            agent_output_key = key
+            break
+
+    if agent_output_key is None:
+        return {
+            "adapter": adapter_name,
+            "status": "error",
+            "error": "No agent output directory configured",
+        }
+
+    output_dir = repo_root / output_config[agent_output_key]
+
+    # Find all role files
+    role_files = [f for f in roles_dir.glob("*.md") if f.name != "_index.md"]
+
+    # Generate output for each role
+    generated_files = []
+    skipped_files = []
+
+    for role_file in role_files:
+        role_name = role_file.stem
+
+        # Parse role file
+        try:
+            frontmatter, body = parse_role_file(role_file)
+        except ValueError as e:
+            continue  # Skip invalid role files
+
+        # Resolve model for this role
+        model_config = {}
+        if model_set:
+            model_config = resolve_model_for_role(role_name, model_set)
+
+        # Generate output content
+        output_content = generate_output_file(
+            role_name,
+            frontmatter,
+            body,
+            adapter_config,
+            model_config,
+            model_set_name or "default",
+        )
+
+        # Compute hash
+        content_hash = compute_content_hash(output_content)
+
+        # Build output path
+        filename_template = adapter_config.get("roles", {}).get("filename", "{name}.md")
+        filename = filename_template.format(name=role_name)
+        output_path = output_dir / filename
+
+        # Check if we should skip (hash-based)
+        skip = False
+        if not force and output_path.exists():
+            existing_hash = _sha256_file(output_path)
+            if existing_hash == content_hash:
+                skip = True
+                skipped_files.append(str(output_path.relative_to(repo_root)))
+
+        if not skip:
+            if not dry_run:
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(output_content)
+            generated_files.append(str(output_path.relative_to(repo_root)))
+
+    # Update manifest
+    generation_info = {
+        "last_generated": datetime.utcnow().isoformat() + "Z",
+        "model_set": model_set_name,
+        "model_set_hash": model_set_hash,
+        "adapter_config_hash": _sha256_file(adapter_path / "adapter.yaml"),
+        "files": generated_files + skipped_files,
+    }
+
+    if not dry_run:
+        update_manifest(manifest_path, adapter_name, generation_info)
+
+    return {
+        "adapter": adapter_name,
+        "status": "success",
+        "model_set": model_set_name,
+        "roles_generated": len(generated_files),
+        "roles_skipped": len(skipped_files),
+        "skills_symlink_created": skills_config.get("strategy") == "symlink",
+        "dry_run": dry_run,
+        "generated_files": generated_files,
+        "skipped_files": skipped_files,
+    }
+
+
+def main() -> None:
+    """Main entry point for aix-generate script."""
+    parser = argparse.ArgumentParser(
+        description="Generate tool-specific configurations from canonical AIX roles"
+    )
+    parser.add_argument(
+        "--adapter",
+        help="Adapter to generate (claude, opencode, factory, agentskills, or 'all')",
+    )
+    parser.add_argument(
+        "--model-set",
+        help="Model set to use (overrides tier.yaml and adapter default)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Generate all enabled adapters from tier.yaml",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be generated without writing files",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Regenerate all files even if unchanged",
+    )
+    parser.add_argument(
+        "--repo-root",
+        help="Path to repository root (default: git root)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output results as JSON",
+    )
+
+    args = parser.parse_args()
+
+    # Determine repo root
+    repo_root = Path(args.repo_root) if args.repo_root else _git_root()
+
+    # Determine which adapters to generate
+    adapters_to_generate = {}
+
+    if args.all:
+        # Get enabled adapters from tier.yaml
+        adapters_to_generate = get_enabled_adapters(repo_root)
+        if not adapters_to_generate:
+            # If no tier.yaml config, generate all available adapters
+            adapters_dir = repo_root / ".aix" / "adapters"
+            if adapters_dir.exists():
+                for adapter_dir in adapters_dir.iterdir():
+                    if adapter_dir.is_dir() and not adapter_dir.name.startswith("_"):
+                        adapters_to_generate[adapter_dir.name] = None
+    elif args.adapter:
+        adapters_to_generate[args.adapter] = args.model_set
+    else:
+        parser.error("Must specify --adapter or --all")
+
+    # Generate each adapter
+    results = []
+    for adapter_name, model_set in adapters_to_generate.items():
+        result = generate_adapter(
+            repo_root,
+            adapter_name,
+            model_set_name=model_set,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+        results.append(result)
+
+    # Output results
+    if args.json:
+        print(json.dumps({"results": results}, indent=2))
+    else:
+        print("AIX Generate Report")
+        print(f"- Repo: {repo_root}")
+        print(f"- Dry Run: {args.dry_run}")
+        print(f"- Force: {args.force}")
+        print()
+
+        for result in results:
+            adapter = result["adapter"]
+            status = result["status"]
+
+            print(f"Adapter: {adapter}")
+            print(f"  Status: {status}")
+
+            if status == "error":
+                print(f"  Error: {result['error']}")
+            else:
+                if result.get("model_set"):
+                    print(f"  Model Set: {result['model_set']}")
+                print(f"  Roles Generated: {result.get('roles_generated', 0)}")
+                print(f"  Roles Skipped: {result.get('roles_skipped', 0)}")
+                print(f"  Skills Symlink: {result.get('skills_symlink_created', False)}")
+
+                if result.get("generated_files"):
+                    print(f"  Generated Files:")
+                    for f in result["generated_files"]:
+                        print(f"    - {f}")
+
+                if result.get("skipped_files"):
+                    print(f"  Skipped Files (unchanged):")
+                    for f in result["skipped_files"]:
+                        print(f"    - {f}")
+
+            print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add adapter architecture supporting multiple coding assistants with user selection during bootstrap.

## Changes

**Registry (tier 0):**
- `adapter-core` - Generator script
- `adapter-claude` - Claude Code
- `adapter-opencode` - OpenCode
- `adapter-factory` - Factory/droid
- `adapter-agentskills` - Skills-only (MCP tools)

**Bootstrap:**
- Interactive adapter selection prompt
- `--adapter <name>` flag for non-interactive use
- Generates adapter configs via `aix-generate.py`
- Updates tier.yaml with `adapters:` section

**Generator (aix-generate.py):**
- Generates tool-specific configs from canonical roles
- Handles format differences (Claude: array, OpenCode: object)
- Tool name mapping (e.g., Write→Create for Factory)
- Model set support per adapter

## Usage

```bash
# Interactive
./bootstrap.sh

# Non-interactive
./bootstrap.sh --adapter opencode
ADAPTER=factory ./bootstrap.sh
```

## Test Plan

- [ ] Bootstrap new project with each adapter
- [ ] Verify generated configs match expected format
- [ ] Test adapter selection prompt
- [ ] Test --adapter flag