### PR TITLE
feat(adapters): add Kiro CLI adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,24 @@ The **constitution + workflow + role** trinity with **approval gates** and **pro
 
 ## What Makes aix Special
 
-- Agents/roles, skills, and hooks are first-class; there are richer collections elsewhere, and aix is designed to integrate them, not replace them.
+- **Multi-tool**: First-class support for Claude Code, Kiro CLI, OpenCode, Factory, and Agent Skills — same methodology, any tool.
+- **Adapter system**: Roles, skills, and constitution translate automatically to each tool's native format.
+- **Model sets**: Configure which models power each role — swap between budget, mid, and pro tiers per adapter.
 - Compaction-aware by default: hooks persist/restore context for Claude Code sessions.
-- Constitution + workflows are familiar; the difference is the combination with roles/skills/hooks and how they are enforced together.
 - Progressive enforcement: start minimal, grow as the project matures, or simplify later.
 - Safe evolution: adopt improvements from newer AIX versions without overwriting local customizations.
-- Primary support is Claude Code; other tool integrations (symlinks for constitutions/skills) are possible but not the current focus.
+
+---
+
+## Supported Adapters
+
+| Adapter | Tool | Constitution | Roles | Skills | Model Sets |
+|---------|------|-------------|-------|--------|------------|
+| **claude-code** | Claude Code | `CLAUDE.md` symlink | `.claude/agents/` (markdown) | `.claude/skills/` symlink | default |
+| **kiro-cli** | Kiro CLI | `AGENTS.md` symlink | `.kiro/agents/` (JSON) | `.kiro/skills/` symlink | budget, mid, pro |
+| **opencode** | OpenCode | `AGENTS.md` symlink | `.opencode/agent/` (markdown) | `.opencode/skills/` symlink | antigravity |
+| **factory** | Factory/Droid | `GEMINI.md` symlink | `.factory/droids/` (markdown) | `.factory/skills/` symlink | balanced, optimal, speed |
+| **agentskills** | MCP-based tools | — | — | `.agent/skills/` symlink | — |
 
 ---
 
@@ -54,11 +66,11 @@ aix grows with your project:
 # Create your project directory
 mkdir my-project && cd my-project
 
-# Bootstrap aix (run from your project directory)
+# Bootstrap aix (select your coding assistant)
 ~/tools/aix/bootstrap.sh
 
-# Open Claude Code
-claude
+# Or specify adapter directly
+ADAPTER=kiro ~/tools/aix/bootstrap.sh
 ```
 
 ### Existing Project
@@ -66,6 +78,13 @@ claude
 ```bash
 cd my-existing-project
 ~/tools/aix/bootstrap.sh
+```
+
+### With a Model Set
+
+```bash
+# Generate roles with a specific model set
+python3 .aix/scripts/aix-generate.py --adapter kiro --model-set pro
 ```
 
 ### Upgrading
@@ -79,7 +98,7 @@ The init skill will:
 1. Detect your tech stack (or ask)
 2. Generate appropriate tier structure
 3. Create input document templates
-4. Set up Claude Code integration
+4. Set up your chosen adapter's integration
 
 ---
 
@@ -88,19 +107,15 @@ The init skill will:
 **Most projects:** Bootstrap copies files into your project (simple, self-contained)
 
 ```bash
-# Current (while private)
-git clone git@github.com:ebblyn/aix.git ~/tools/aix
+git clone git@github.com:ryangaraygay/aix.git ~/tools/aix
 cd my-project
 ~/tools/aix/bootstrap.sh
-
-# Future (when public)
-curl -fsSL https://aix.dev/install | bash
 ```
 
 **AIX contributors:** Submodule for tight coupling
 
 ```bash
-git submodule add git@github.com:ebblyn/aix.git .aix
+git submodule add git@github.com:ryangaraygay/aix.git .aix
 ./.aix/adapters/claude-code/generate.sh 0
 ```
 
@@ -122,25 +137,31 @@ Every project needs these (templates provided):
 
 ## Directory Structure
 
-After `/aix-init`, your project will have:
+After bootstrap, your project will have:
 
 ```
 your-project/
-├── CLAUDE.md              # → .aix/constitution.md
-├── .claude/
-│   ├── agents/            # → .aix/roles/
-│   └── skills/            # → .aix/skills/
-├── .aix/
-│   ├── constitution.md    # Principles
-│   ├── config.yaml        # Settings
-│   ├── tier.yaml          # Current tier + history
-│   ├── workflows/         # How work flows
-│   ├── roles/             # Who does what
-│   └── skills/            # Reusable automation
+├── .aix/                     # Core framework (adapter-agnostic)
+│   ├── constitution.md       # Principles
+│   ├── config.yaml           # Settings
+│   ├── tier.yaml             # Current tier + adapter config
+│   ├── workflows/            # How work flows
+│   ├── roles/                # Who does what (canonical)
+│   ├── skills/               # Reusable automation
+│   └── adapters/             # Adapter configs + model sets
 └── docs/
     ├── product.md
     ├── tech-stack.md
     └── design.md
+```
+
+Plus adapter-specific output (examples):
+
+```
+# Claude Code                  # Kiro CLI
+CLAUDE.md → constitution        AGENTS.md → constitution
+.claude/agents/ → roles         .kiro/agents/*.json (generated)
+.claude/skills/ → skills        .kiro/skills/ → skills
 ```
 
 ---

--- a/adapters/kiro-cli/adapter.yaml
+++ b/adapters/kiro-cli/adapter.yaml
@@ -1,0 +1,27 @@
+adapter: kiro
+version: 1
+
+output:
+  agents: .kiro/agents
+  skills: .kiro/skills
+
+skills:
+  strategy: symlink
+
+# Model sets: no default (uses kiro's own model)
+# Pass --model-set budget|mid|pro to override
+model_sets:
+  enabled: true
+
+roles:
+  format: json
+  filename: "{name}.json"
+
+# Kiro-native tool names
+tools:
+  Read: fs_read
+  Write: fs_write
+  Edit: fs_write
+  Bash: execute_bash
+  Grep: grep
+  Glob: glob

--- a/adapters/kiro-cli/generate.sh
+++ b/adapters/kiro-cli/generate.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Generate Kiro CLI files from aix framework
+# Usage: ./adapters/kiro-cli/generate.sh [tier]
+#
+# Supports two patterns:
+# 1. Bootstrapped repos: files copied flat to .aix/
+# 2. Submodule repos: tier structure at .aix/tiers/
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+AIX_DIR="$REPO_ROOT/.aix"
+KIRO_DIR="$REPO_ROOT/.kiro"
+
+# Default tier
+TIER="${1:-0}"
+
+# Map tier to name
+get_tier_name() {
+    case $1 in
+        0) echo "seed" ;;
+        1) echo "sprout" ;;
+        2) echo "grow" ;;
+        3) echo "scale" ;;
+        *) echo "seed" ;;
+    esac
+}
+
+echo "Generating Kiro CLI files for Tier $TIER..."
+
+# Ensure .aix exists
+if [ ! -d "$AIX_DIR" ]; then
+    echo "Error: .aix directory not found. Run bootstrap.sh first."
+    exit 1
+fi
+
+# Detect structure: submodule (has tiers/) vs bootstrapped (flat)
+if [ -d "$AIX_DIR/tiers" ]; then
+    TIER_NAME=$(get_tier_name $TIER)
+    TIER_PATH="tiers/$TIER-$TIER_NAME"
+    CONSTITUTION_PATH=".aix/$TIER_PATH/constitution.md"
+    SKILLS_PATH="../.aix/$TIER_PATH/skills"
+    echo "Detected submodule structure"
+else
+    CONSTITUTION_PATH=".aix/constitution.md"
+    SKILLS_PATH="../.aix/skills"
+    echo "Detected bootstrapped structure"
+fi
+
+# Create AGENTS.md symlink (Kiro auto-loads this like CLAUDE.md)
+if [ -L "$REPO_ROOT/AGENTS.md" ] || [ -f "$REPO_ROOT/AGENTS.md" ]; then
+    rm "$REPO_ROOT/AGENTS.md"
+fi
+ln -s "$CONSTITUTION_PATH" "$REPO_ROOT/AGENTS.md"
+echo "✓ Created AGENTS.md symlink -> $CONSTITUTION_PATH"
+
+# Create .kiro directory
+mkdir -p "$KIRO_DIR"
+
+# Create skills symlink
+if [ -L "$KIRO_DIR/skills" ] || [ -d "$KIRO_DIR/skills" ]; then
+    rm -rf "$KIRO_DIR/skills"
+fi
+if [ -d "$AIX_DIR/skills" ] || [ -d "$AIX_DIR/$TIER_PATH/skills" ] 2>/dev/null; then
+    ln -s "$SKILLS_PATH" "$KIRO_DIR/skills"
+    echo "✓ Created .kiro/skills symlink -> $SKILLS_PATH"
+fi
+
+# Generate agent JSON files via aix-generate.py
+if [ -f "$AIX_DIR/scripts/aix-generate.py" ]; then
+    echo "Generating agent configurations..."
+    python3 "$AIX_DIR/scripts/aix-generate.py" --adapter kiro 2>/dev/null || true
+fi
+
+echo ""
+echo "Kiro CLI setup complete!"
+echo ""
+echo "Files created:"
+echo "  - AGENTS.md -> $CONSTITUTION_PATH"
+echo "  - .kiro/skills/ -> $SKILLS_PATH"
+echo "  - .kiro/agents/*.json (generated roles)"

--- a/adapters/kiro-cli/model-sets/budget.yaml
+++ b/adapters/kiro-cli/model-sets/budget.yaml
@@ -1,0 +1,13 @@
+name: budget
+description: Cost-effective models - MiniMax for agentic/tool-use, Qwen for coding, DeepSeek for reasoning
+
+roles:
+  orchestrator: minimax-m2.1
+  analyst: minimax-m2.1
+  coder: qwen3-coder-next
+  reviewer: minimax-m2.1
+  debug: minimax-m2.1
+  product-designer: minimax-m2.1
+  tester: qwen3-coder-next
+  docs: minimax-m2.1
+  triage: minimax-m2.1

--- a/adapters/kiro-cli/model-sets/mid.yaml
+++ b/adapters/kiro-cli/model-sets/mid.yaml
@@ -1,0 +1,13 @@
+name: mid
+description: Balanced Claude models - Sonnet for heavy lifting, Haiku for light tasks
+
+roles:
+  orchestrator: claude-sonnet-4.5
+  analyst: claude-sonnet-4.5
+  coder: claude-sonnet-4.5
+  reviewer: claude-sonnet-4.5
+  debug: claude-sonnet-4.5
+  product-designer: claude-sonnet-4.5
+  tester: claude-haiku-4.5
+  docs: claude-haiku-4.5
+  triage: claude-sonnet-4.5

--- a/adapters/kiro-cli/model-sets/pro.yaml
+++ b/adapters/kiro-cli/model-sets/pro.yaml
@@ -1,0 +1,13 @@
+name: pro
+description: Premium Claude models - Opus for reasoning-heavy roles, Sonnet for execution
+
+roles:
+  orchestrator: claude-opus-4.6
+  analyst: claude-opus-4.6
+  coder: claude-sonnet-4.5
+  reviewer: claude-opus-4.6
+  debug: claude-opus-4.6
+  product-designer: claude-opus-4.6
+  tester: claude-sonnet-4.5
+  docs: claude-sonnet-4.5
+  triage: claude-sonnet-4.5

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -164,6 +164,7 @@ select_adapter() {
     echo "  2) OpenCode"
     echo "  3) Factory/Droid"
     echo "  4) Agent Skills (MCP-based tools)"
+    echo "  5) Kiro CLI"
     echo ""
     read -p "Enter choice [1]: " choice
 
@@ -171,6 +172,7 @@ select_adapter() {
         2) echo "opencode" ;;
         3) echo "factory" ;;
         4) echo "agentskills" ;;
+        5) echo "kiro" ;;
         *) echo "claude" ;;
     esac
 }
@@ -208,6 +210,7 @@ case "$SELECTED_ADAPTER" in
     opencode) ADAPTER_DIR="opencode" ;;
     factory) ADAPTER_DIR="factory" ;;
     agentskills) ADAPTER_DIR="agentskills" ;;
+    kiro) ADAPTER_DIR="kiro-cli" ;;
 esac
 
 DEFAULT_MODEL_SET=""
@@ -250,6 +253,12 @@ case "$SELECTED_ADAPTER" in
         ;;
     agentskills)
         # No entry point needed for agent skills
+        ;;
+    kiro)
+        # Run Kiro CLI adapter script
+        if [ -f "$AIX_FRAMEWORK/adapters/kiro-cli/generate.sh" ]; then
+            "$AIX_FRAMEWORK/adapters/kiro-cli/generate.sh" 0
+        fi
         ;;
 esac
 
@@ -308,6 +317,13 @@ case "$SELECTED_ADAPTER" in
     agentskills)
         echo "  .agent/"
         echo "  └── skills/"
+        ;;
+    kiro)
+        echo "  .kiro/"
+        echo "  ├── agents/"
+        echo "  └── skills/"
+        echo ""
+        echo "  AGENTS.md -> .aix/constitution.md"
         ;;
 esac
 

--- a/registry.tsv
+++ b/registry.tsv
@@ -4,6 +4,7 @@ adapter-claude	0	adapter	adapters/claude-code	Claude Code adapter
 adapter-opencode	0	adapter	adapters/opencode	OpenCode adapter
 adapter-factory	0	adapter	adapters/factory	Factory/droid adapter
 adapter-agentskills	0	adapter	adapters/agentskills	Skills-only adapter (MCP tools)
+adapter-kiro	0	adapter	adapters/kiro-cli	Kiro CLI adapter
 test	1	skill	skills/test	Run tests
 commit	1	skill	skills/commit	Commit helper
 tester	1	role	roles/tester.md	Tester role


### PR DESCRIPTION
## Summary
- Add Kiro CLI adapter that converts AIX roles to JSON agent configs (`.kiro/agents/*.json`)
- Symlinks skills (`.kiro/skills/`) and constitution (`AGENTS.md`) using Kiro's native conventions
- Maps AIX tool names to Kiro equivalents (Read→fs_read, Bash→execute_bash, etc.)
- Three model sets: budget (MiniMax/Qwen), mid (Sonnet/Haiku), pro (Opus/Sonnet)
- Extends `aix-generate.py` to support JSON output format with optional model set defaulting
- Adds Kiro as option 5 in `bootstrap.sh` adapter selection

## Test plan
- [x] Bootstrapped test project with `ADAPTER=kiro`
- [x] All 3 generated agents pass `kiro-cli agent validate`
- [x] `kiro-cli agent list` shows workspace agents correctly
- [x] Tool name mapping verified in both `tools` array and prompt body
- [x] Model sets tested: no default (null), budget, mid, pro
- [x] Skills symlink resolves correctly
- [x] AGENTS.md symlink resolves correctly