### PR TITLE
fix(kiro-cli): use correct tool names and populate allowedTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ Thumbs.db
 *.swp
 *.swo
 
+# Python
+*.pyc
+__pycache__/
+.coverage
+
 # Environment
 .env
 .env.local

--- a/adapters/kiro-cli/adapter.yaml
+++ b/adapters/kiro-cli/adapter.yaml
@@ -19,9 +19,9 @@ roles:
 
 # Kiro-native tool names
 tools:
-  Read: fs_read
-  Write: fs_write
-  Edit: fs_write
-  Bash: execute_bash
+  Read: read
+  Write: write
+  Edit: write
+  Bash: shell
   Grep: grep
   Glob: glob

--- a/scripts/aix-generate.py
+++ b/scripts/aix-generate.py
@@ -343,7 +343,7 @@ def generate_json_agent(
         "mcpServers": {},
         "tools": mapped_tools,
         "toolAliases": {},
-        "allowedTools": [],
+        "allowedTools": mapped_tools,
         "resources": [],
         "hooks": {},
         "toolsSettings": {},


### PR DESCRIPTION
## Summary
- Fix kiro-cli adapter tool name mappings to use canonical names (`read`, `write`, `shell`) instead of Claude Code SDK names (`fs_read`, `fs_write`, `execute_bash`)
- Populate `allowedTools` from the agent's tool list instead of hardcoding to empty array — this was causing every tool call to prompt for user approval, even in subagents with pre-defined tools
- Add Python gitignore entries (`.coverage`, `__pycache__/`, `*.pyc`)

## Test plan
- [x] Verified fix on kev_scanner project — subagent tool calls no longer prompt for approval
- [x] Ran `aix-generate.py --adapter kiro --force` and confirmed generated agents have correct tool names and populated `allowedTools`
- [x] Ran `aix-sync.py` from kev_scanner to confirm both repos converge cleanly