### PR TITLE
fix(kiro-cli): use correct tool names and populate allowedTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ Thumbs.db
 *.swp
 *.swo
 
+# Python
+*.pyc
+__pycache__/
+.coverage
+
 # Environment
 .env
 .env.local

--- a/adapters/kiro-cli/adapter.yaml
+++ b/adapters/kiro-cli/adapter.yaml
@@ -19,9 +19,9 @@ roles:
 
 # Kiro-native tool names
 tools:
-  Read: fs_read
-  Write: fs_write
-  Edit: fs_write
-  Bash: execute_bash
+  Read: read
+  Write: write
+  Edit: write
+  Bash: shell
   Grep: grep
   Glob: glob

--- a/scripts/aix-generate.py
+++ b/scripts/aix-generate.py
@@ -343,7 +343,7 @@ def generate_json_agent(
         "mcpServers": {},
         "tools": mapped_tools,
         "toolAliases": {},
-        "allowedTools": [],
+        "allowedTools": mapped_tools,
         "resources": [],
         "hooks": {},
         "toolsSettings": {},


### PR DESCRIPTION
Kiro CLI uses canonical tool names (read, write, shell) not Claude Code SDK names (fs_read, fs_write, execute_bash). The adapter mapping was producing agent configs with wrong names, and allowedTools was hardcoded to an empty array — causing every tool call to prompt for user approval even in subagents with pre-defined tool lists.

- Fix adapter.yaml tool mappings to kiro canonical names
- Populate allowedTools from mapped_tools instead of empty array
- Add Python gitignore entries (.coverage, __pycache__, *.pyc)