### PR TITLE
fix(workflows): require reading docs before skipping Phase 4

### DIFF
--- a/tiers/2-grow/workflows/feature.md
+++ b/tiers/2-grow/workflows/feature.md
@@ -401,11 +401,21 @@ Infrastructure changes (Docker, CI/CD, networking) have different risk profiles 
 **Role**: docs
 **Purpose**: Update documentation if the change has user-facing impact
 
+### Mandatory Check
+
+Before deciding whether to skip this phase, **read** the following files (if they exist):
+- `docs/roadmap.md`
+- `docs/capabilities.md`
+
+If either file references the work being completed, update it. Follow each file's stated conventions (e.g., roadmap may be future-work-only with completed items removed, capabilities may be completed-work-only).
+
+Do not decide "no docs needed" from memory. Read first, then decide.
+
 ### When to Run
 
 | Impact | Action |
 |--------|--------|
-| No docs needed | Skip this phase |
+| No docs needed (verified by reading) | Skip this phase |
 | Internal docs | Update developer documentation |
 | External docs | Update user-facing documentation |
 | Both | Update both |

--- a/tiers/2-grow/workflows/refactor.md
+++ b/tiers/2-grow/workflows/refactor.md
@@ -274,13 +274,23 @@ Create: `.aix/plans/{refactor-name}/plan.md`
 > **No manual verification phase** - refactors don't have UI to verify.
 > Skip straight to docs if applicable.
 
+### Mandatory Check
+
+Before deciding whether to skip this phase, **read** the following files (if they exist):
+- `docs/roadmap.md`
+- `docs/capabilities.md`
+
+If either file references the work being completed, update it. Follow each file's stated conventions (e.g., roadmap may be future-work-only with completed items removed, capabilities may be completed-work-only).
+
+Do not decide "no docs needed" from memory. Read first, then decide.
+
 ### When to Run
 
-Check `doc_impact` from analyst plan:
+Check `doc_impact` from analyst plan, **after** the mandatory check above:
 
 | doc_impact | Action |
 |------------|--------|
-| `none` | Skip this phase |
+| `none` (verified by reading) | Skip this phase |
 | `internal` | Update internal docs (READMEs, guides, architecture docs) |
 
 > For refactors, `doc_impact` is typically `none` or `internal` only.


### PR DESCRIPTION
## Summary

- Add mandatory check to Phase 4 (Documentation) in feature and refactor workflows
- Before deciding to skip docs, the agent must **read** `docs/roadmap.md` and `docs/capabilities.md`
- Prevents completed roadmap items from silently not being moved to capabilities

## Context

During P0-A1 implementation on aix-factor, the feature workflow's Phase 4 was skipped without reading the docs. A completed roadmap item was not moved to capabilities because the skip decision was made from memory, not verification. This violates Constitution Principle #4 (Verify Before Claiming) but wasn't operationalized in the workflow.

## Test plan

- [x] Markdown-only change, no code to test
- [x] Verified wording is consistent between feature.md and refactor.md
- [x] Synced downstream to aix-factor to confirm clean merge