### PR TITLE
docs: add TRADEMARK.md (narrow common-law name policy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,7 @@ aix embodies this: you focus on the "why" and "what", AI handles the "how".
 ## License
 
 MIT - See [LICENSE](LICENSE)
+
+## Trademark
+
+The "AIX" name is a reserved project identifier — see [TRADEMARK.md](TRADEMARK.md). Code is MIT (use freely); the name is governed by the trademark policy. TL;DR: refer to AIX freely, do not rename your fork "AIX".

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,78 @@
+# AIX Trademark Policy
+
+## Summary
+
+"AIX" is the name of this open-source AI development methodology framework. The code is freely licensed under the [MIT License](LICENSE); the **name** is reserved so the project's identity stays clear in the community.
+
+This policy explains what is allowed without asking, what is not, and how to request permission for anything in between.
+
+## What this policy covers
+
+Within the scope of **AI development tooling and methodology frameworks**, this policy applies to:
+
+- The name "AIX" / "aix" (any casing)
+- Confusable variants intended to invoke this project (e.g. "AIXX", "Aix-Pro", "MyAIX", "OpenAIX")
+- The `.aix/` directory naming convention used by the framework
+
+It does **not** assert any rights over:
+
+- The methodology itself — the "constitution + workflow + role" pattern, approval gates, progressive enforcement, and related ideas. Anyone may re-implement the methodology under their own name.
+- Uses of "AIX" in unrelated contexts. Most notably, **IBM AIX®** is a registered trademark of IBM Corporation for an enterprise Unix operating system — a different domain from this project. Nothing in this policy is intended to assert against unrelated prior uses.
+
+## Permitted use without asking
+
+You can do all of the following without permission:
+
+- Refer to AIX in articles, talks, blog posts, social media, or documentation (e.g. "we use AIX", "built on AIX", "an AIX skill")
+- State factual compatibility (e.g. "compatible with AIX", "AIX adapter for [tool]")
+- Fork the repository under the MIT License
+- Modify, extend, criticize, compare, or review the project
+- Adopt AIX into your own projects — this is the whole point
+
+## Use that needs permission or is not allowed
+
+Please do not, without permission:
+
+- Name a fork or competing project "AIX" or a confusable variant ("AIX2", "OpenAIX", "AIX Pro", etc.) — pick your own name
+- Use "AIX" as a brand identifier for a product, company, or service
+- Imply official endorsement, sponsorship, or affiliation that does not exist
+
+If you want to do any of these, open a GitHub issue to discuss.
+
+## Code, name, and methodology — the distinction
+
+| What | Status | What you can do |
+|---|---|---|
+| **Code** (scripts, configs, templates) | MIT-licensed | Fork, use, modify, redistribute freely |
+| **Name** ("AIX", `.aix/`) | Reserved (this policy) | Refer to AIX freely; do not rename your fork to AIX |
+| **Methodology** (the ideas) | Not protected by this policy | Re-implement freely under your own name |
+
+This separation is intentional. The code is free, the methodology is free, and the name is reserved so the community has a stable identifier for *this* project specifically.
+
+## Forks
+
+Forks of the AIX repository are welcome under the MIT License. If you distribute a fork under its own banner, please rename it — not "AIX-fork", "AIX2", or similar. A clean new name avoids confusion and is the kind thing to do for downstream users.
+
+Compatible reimplementations of the methodology are fine and do not need to coordinate with this project — just do not claim to be AIX.
+
+## Requesting permission
+
+Open a GitHub issue at <https://github.com/ryangaraygay/aix/issues> describing the use you have in mind. Responses will come as time allows.
+
+## Enforcement
+
+This is a small, non-commercial open-source project. If a use causes confusion with AIX in its niche, the maintainer may politely ask for a rename. Further steps would only be considered if a rename request is ignored or in cases of clear bad faith.
+
+## Basis
+
+This is a common-law trademark claim based on continuous public use of "AIX" as the name of this project since 2026. The name is not registered.
+
+## License of this policy
+
+This document is licensed under [Creative Commons Attribution 4.0](https://creativecommons.org/licenses/by/4.0/). You may adapt it for your own project's trademark policy with attribution.
+
+## Updates
+
+This policy may be revised. The current version is tracked in this file's git history.
+
+Last updated: 2026-04-25.


### PR DESCRIPTION
## Summary

Adds a `TRADEMARK.md` and a short README pointer establishing a narrow common-law trademark claim on the "AIX" name within the AI development methodology framework niche.

Closes the trademark item from #21.

## Why narrow

IBM AIX® has existed as a registered trademark since 1986 (enterprise Unix OS). This project's "AIX" operates in a different domain (AI development methodology), but a loud trademark assertion would be both legally weaker than it sounds and unnecessarily provocative given non-commercial intent.

The policy therefore:

- Scopes the claim explicitly to "AI development tooling and methodology frameworks"
- Acknowledges IBM AIX directly as a separate prior use, asserting no rights against it
- Keeps enforcement language soft ("politely ask for a rename")
- Frames code/name/methodology as three distinct things — code is MIT, methodology is unprotected, name is reserved

## What's protected vs not

| What | Status |
|---|---|
| Code (scripts, configs, templates) | MIT-licensed — fork freely |
| Name ("AIX", `.aix/` directory) | Reserved per this policy |
| Methodology (constitution + workflow + role pattern) | Not protected — anyone may re-implement under their own name |

## Files

- `TRADEMARK.md` — the policy itself (CC BY 4.0 so others can adapt for their own projects)
- `README.md` — short Trademark section pointing at the policy

## Test plan

- [x] Policy text reviewed for tone (friendly, not threatening)
- [x] IBM AIX acknowledged explicitly
- [x] No claim of registration (common-law only)
- [x] Methodology/code/name distinction is clear
- [x] Permission request mechanism uses GitHub Issues (no email PII)