### PR TITLE
ci: enable DCO check on PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,10 +15,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Verify Signed-off-by on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
           missing=0
           while read -r sha; do
             if ! git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' "$sha" | grep -q .; then
@@ -27,7 +28,7 @@ jobs:
               echo "::error::Commit $sha by $author missing Signed-off-by — \"$subject\""
               missing=1
             fi
-          done < <(git rev-list "$base".."$head")
+          done < <(git rev-list "$BASE_SHA".."$HEAD_SHA")
           if [ "$missing" -ne 0 ]; then
             echo ""
             echo "Fix: amend each missing commit with"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,42 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-dco:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.type != 'Bot'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Verify Signed-off-by on every commit
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          missing=0
+          while read -r sha; do
+            if ! git log -1 --format='%(trailers:key=Signed-off-by,valueonly)' "$sha" | grep -q .; then
+              author=$(git log -1 --format='%an <%ae>' "$sha")
+              subject=$(git log -1 --format='%s' "$sha")
+              echo "::error::Commit $sha by $author missing Signed-off-by — \"$subject\""
+              missing=1
+            fi
+          done < <(git rev-list "$base".."$head")
+          if [ "$missing" -ne 0 ]; then
+            echo ""
+            echo "Fix: amend each missing commit with"
+            echo "    git commit --amend -s --no-edit    # for the latest commit"
+            echo "or, for multiple commits, use"
+            echo "    git rebase --signoff main"
+            echo "then push with --force-with-lease."
+            echo ""
+            echo "See CONTRIBUTING.md for the DCO sign-off explanation."
+            exit 1
+          fi
+          echo "All commits signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,6 +208,28 @@ New tiers should be discussed in an issue first. Tiers follow the progression:
 
 By contributing to AIX, you agree that your contributions will be licensed under the MIT License (see [LICENSE](LICENSE)).
 
+## Sign your commits (DCO)
+
+AIX uses the [Developer Certificate of Origin](https://developercertificate.org/) (DCO). Every commit in a pull request must include a `Signed-off-by:` trailer affirming that you wrote the contribution (or otherwise have the right to submit it under the project's license).
+
+Sign each commit by adding `-s` when you commit:
+
+```bash
+git commit -s -m "your message"
+```
+
+This appends a line like `Signed-off-by: Your Name <your.email@example.com>` to the commit message, using your `git config user.name` and `user.email`.
+
+A CI check verifies sign-off on every commit. If you forget:
+
+```bash
+git commit --amend -s --no-edit          # for the latest commit
+git rebase --signoff main                # for multiple commits
+git push --force-with-lease              # update the PR branch
+```
+
+Bot-authored PRs (e.g. Dependabot) are exempt from the check.
+
 ## Questions?
 
 - Open an issue for questions

--- a/README.md
+++ b/README.md
@@ -194,3 +194,7 @@ MIT - See [LICENSE](LICENSE)
 ## Trademark
 
 The "AIX" name is a reserved project identifier — see [TRADEMARK.md](TRADEMARK.md). Code is MIT (use freely); the name is governed by the trademark policy. TL;DR: refer to AIX freely, do not rename your fork "AIX".
+
+## Contributing
+
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Commits must be signed off (DCO): use `git commit -s`. A CI check enforces this on every PR.


### PR DESCRIPTION
## Summary

Adds a Developer Certificate of Origin (DCO) check that runs on every PR to `main` and fails if any commit is missing a `Signed-off-by:` trailer.

Closes the DCO portion of #21.

## Why DCO over a CLA

DCO is the lighter-weight industry standard:

- One-line affirmation in each commit message (added by `git commit -s`)
- No separate signing portal, no PDFs, no per-contributor agreement
- Used by Linux kernel, Docker, Kubernetes, GitLab, and (since 2024) the Apache Software Foundation

For AIX specifically:

- Locks in clean contributor provenance early, while contributor history is still small
- Fits the project's "pure OSS forever" stance — no dual-licensing rationale exists, so a CLA would be overkill
- Lighter friction than a CLA for one-off contributors

## Why a custom in-repo workflow over a third-party app

Two reasons that match the project's stated preferences:

1. **Lives in the repo** — version-controlled, auditable, no GitHub App with extra permissions on the org
2. **No third-party dependency** — the check is ~25 lines of bash, easy to read and maintain

## What the workflow does

- Runs on `pull_request` to `main`
- Walks every commit in the PR's range (`base..head`)
- Fails the check if any commit lacks a `Signed-off-by:` trailer, with a friendly fix-path message
- Skips entirely for bot-authored PRs (Dependabot etc.) via `github.event.pull_request.user.type != 'Bot'`

## CONTRIBUTING.md

Adds a "Sign your commits (DCO)" section explaining:

- What sign-off means (DCO link)
- How to add it (`git commit -s`)
- How to fix forgotten sign-offs (`--amend -s` or `rebase --signoff`)
- The bot exemption

## Test plan

- [x] This PR's commit is signed off (the workflow will run on its own PR — meta-test)
- [ ] Verify the DCO check shows green on this PR after push
- [x] CONTRIBUTING.md sign-off section reads naturally
- [x] Workflow file passes a quick syntax sanity check (valid YAML, valid Actions schema)

## Future considerations (out of scope)

- If contributor volume grows enough that forgotten sign-offs become annoying, we can add an auto-correct PR comment or a setup-friendly action like `tim-actions/dco`. For now the in-repo bash check is sufficient.